### PR TITLE
Improve flexibility of the hyphenation module

### DIFF
--- a/hyphenation.lisp
+++ b/hyphenation.lisp
@@ -3,16 +3,23 @@
 
 (in-package #:typeset)
 
-(defun hyphenate-string (string)
-  (let ((min-word-size (+ cl-typesetting-hyphen::*left-hyphen-minimum* cl-typesetting-hyphen::*right-hyphen-minimum*)))
+(defparameter *default-hyphen-language* :american)
+
+(defun hyphenate-string (string &optional (language *default-hyphen-language*))
+  "Builds a list of hyphenation points.
+With optional second argument `LANGUAGE', use hyphenation data for
+that language."
+  (let ((min-word-size (+ cl-tt-hyph::*left-hyphen-minimum*
+			  cl-tt-hyph::*right-hyphen-minimum*))
+	(hyphen-language (cl-tt-hyph:language-hyphenation language)))
     (when (>= (length string) min-word-size)
       (loop
-	  for prev-word-end = 0 then word-end
-	  for word-start = (position-if #'alpha-char-p string :start prev-word-end)
-	  for word-end = (when word-start (position-if-not #'alpha-char-p string :start word-start))
-	  while word-end
-	  when (>= (- word-end word-start) min-word-size)
-	  nconc (mapcar #'(lambda (n) (+ word-start n))
-			(cl-typesetting-hyphen::hyphen-find-hyphen-points
-			 cl-typesetting-hyphen::*american-hyphen-trie* (subseq string word-start word-end)))))))
-
+	 for prev-word-end = 0 then word-end
+	 for word-start = (position-if #'alpha-char-p string :start prev-word-end)
+	 for word-end = (when word-start (position-if-not #'alpha-char-p string :start word-start))
+	 while word-end
+	 when (>= (- word-end word-start) min-word-size)
+	 nconc (mapcar #'(lambda (n) (+ word-start n))
+		       (cl-tt-hyph::hyphen-find-hyphen-points
+			hyphen-language
+			(subseq string word-start word-end)))))))

--- a/zzinit.lisp
+++ b/zzinit.lisp
@@ -24,16 +24,15 @@ value, and force initialization of American and French hyphenation tries."
 	  *font* *default-font*))
 
   (when hyphen-patterns-directory
-    (setq cl-typesetting-hyphen::*hyphen-patterns-directory* hyphen-patterns-directory))
+    (setq cl-tt-hyph::*hyphen-patterns-directory* hyphen-patterns-directory))
   (when (confirm-hyphen-patterns-directory)
-    (cl-typesetting-hyphen::read-hyphen-file cl-typesetting-hyphen::*american-hyphen-trie*)
-    (cl-typesetting-hyphen::read-hyphen-file cl-typesetting-hyphen::*french-hyphen-trie*)
-    cl-typesetting-hyphen::*hyphen-patterns-directory*))
-
+    (setf cl-tt-hyph::*american-hyphen-trie* (cl-tt-hyph:load-language :american))
+    (setf cl-tt-hyph::*french-hyphen-trie*   (cl-tt-hyph:load-language :french))
+    cl-tt-hyph::*hyphen-patterns-directory*))
 
 (defun confirm-hyphen-patterns-directory ()
   (or (#-clisp probe-file #+clisp ext:probe-directory
-	       cl-typesetting-hyphen::*hyphen-patterns-directory*)
+	       cl-tt-hyph::*hyphen-patterns-directory*)
       (warn "You have set the following non-existent hyphen-patterns directory:
 
 ~a
@@ -43,6 +42,7 @@ initialize the system with something like this:
 
   (typeset:initialize! :hyphen-patterns-directory \"/usr/share/hyphen-patterns/\")
 "
-	    cl-typesetting-hyphen::*hyphen-patterns-directory*)))
+	    cl-tt-hyph::*hyphen-patterns-directory*)))
 
-(initialize!)
+(eval-when (:load-toplevel)
+  (initialize!))


### PR DESCRIPTION
* Add new (optional) second argument to TYPESET::HYPHENATE-STRING so
  that languages other than :AMERICAN can be hyphenated.

* Export a simple language API from CL-TYPESETTING-HYPHEN.

* Provide means to get rid of hardcoded references to language hyphen
  tries (e.g. *AMERICAN-HYPHEN-TRIE*) and instead use language names.
  Old hyphen trie variables left for compatibility reasons.